### PR TITLE
Distributed the issue categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Argument | Description
 **&#8209;e**, **&#8209;&#8209;end-line**  |  the end line to be analyzed. The default value is `None`, which meant to handle file by the end.
 **&#8209;&#8209;new-format**              |  the argument determines whether the tool should use the _new format_. _New format_ means separating the result by the files to allow getting quality and observed issues for each file separately. The default value is `False`.
 **&#8209;&#8209;history**                 |  JSON string with a list of issues for each language. For each issue its class and quantity are specified. Example: `--history "{\"python\": [{\"origin_class\": \"SC200\", \"number\": 20}, {\"origin_class\": \"WPS314\", \"number\": 3}]}"`
+**&#8209;&#8209;with&#8209;all&#8209;categories** | Without this flag, all issues will be categorized into 5 main categories: `CODE_STYLE`, `BEST_PRACTICES`, `ERROR_PRONE`, `COMPLEXITY`, `INFO`.
 
 The output examples:
 

--- a/src/python/common/tool_arguments.py
+++ b/src/python/common/tool_arguments.py
@@ -78,6 +78,10 @@ class RunToolArgument(Enum):
                             'Json string, which contains lists of issues in the previous submissions '
                             'for other tasks for one user.')
 
+    WITH_ALL_CATEGORIES = ArgumentsInfo(None, '--with-all-categories',
+                                        'Without this flag, all issues will be categorized into 5 main categories: '
+                                        'CODE_STYLE, BEST_PRACTICES, ERROR_PRONE, COMPLEXITY, INFO.')
+
     SOLUTIONS_FILE_PATH = ArgumentsInfo(None, 'solutions_file_path',
                                         'Local XLSX-file or CSV-file path. '
                                         'Your file must include column-names: '

--- a/src/python/review/application_config.py
+++ b/src/python/review/application_config.py
@@ -12,6 +12,7 @@ class ApplicationConfig:
     allow_duplicates: bool
     n_cpu: int
     inspectors_config: dict
+    with_all_categories: bool
     start_line: int = 1
     end_line: Optional[int] = None
     new_format: bool = False

--- a/src/python/review/inspectors/issue.py
+++ b/src/python/review/inspectors/issue.py
@@ -10,29 +10,46 @@ from src.python.review.inspectors.inspector_type import InspectorType
 
 @unique
 class IssueType(Enum):
+    # Code style issues
     CODE_STYLE = 'CODE_STYLE'
-    BEST_PRACTICES = 'BEST_PRACTICES'
-    ERROR_PRONE = 'ERROR_PRONE'
-    FUNC_LEN = 'FUNC_LEN'
     LINE_LEN = 'LINE_LEN'
-    CYCLOMATIC_COMPLEXITY = 'CYCLOMATIC_COMPLEXITY'
+
+    # Best practice issues
+    BEST_PRACTICES = 'BEST_PRACTICES'
+    FUNC_LEN = 'FUNC_LEN'
     BOOL_EXPR_LEN = 'BOOL_EXPR_LEN'
+    CLASS_RESPONSE = 'CLASS_RESPONSE'
+    METHOD_NUMBER = 'METHOD_NUMBER'
+
+    # Error-prone issues
+    ERROR_PRONE = 'ERROR_PRONE'
+
+    # Code complexity issues
     COMPLEXITY = 'COMPLEXITY'
-    ARCHITECTURE = 'ARCHITECTURE'
+    CYCLOMATIC_COMPLEXITY = 'CYCLOMATIC_COMPLEXITY'
     INHERITANCE_DEPTH = 'INHERITANCE_DEPTH'
     CHILDREN_NUMBER = 'CHILDREN_NUMBER'
     WEIGHTED_METHOD = 'WEIGHTED_METHOD'
     COUPLING = 'COUPLING'
     COHESION = 'COHESION'
-    CLASS_RESPONSE = 'CLASS_RESPONSE'
-    METHOD_NUMBER = 'METHOD_NUMBER'
     MAINTAINABILITY = 'MAINTAINABILITY'
+
+    # Info issues
     INFO = 'INFO'
 
+    # Others
     UNDEFINED = 'UNDEFINED'
+    ARCHITECTURE = 'ARCHITECTURE'  # TODO: Distribute into one of the main types
 
     def __str__(self) -> str:
         return ' '.join(self.value.lower().split('_'))
+
+    def to_main_type(self) -> 'IssueType':
+        """
+        Converts the issue type to main issue type.
+        Main issue types: CODE_STYLE, BEST_PRACTICES, ERROR_PRONE, COMPLEXITY, INFO.
+        """
+        return get_main_category_by_issue_type(self)
 
 
 ISSUE_TYPE_TO_MAIN_CATEGORY = {
@@ -60,6 +77,9 @@ ISSUE_TYPE_TO_MAIN_CATEGORY = {
     IssueType.CHILDREN_NUMBER: IssueType.COMPLEXITY,
     IssueType.INHERITANCE_DEPTH: IssueType.COMPLEXITY,
     IssueType.ARCHITECTURE: IssueType.COMPLEXITY,
+
+    # INFO
+    IssueType.INFO: IssueType.INFO,
 }
 
 

--- a/src/python/review/quality/penalty.py
+++ b/src/python/review/quality/penalty.py
@@ -25,6 +25,8 @@ ISSUE_TYPE_TO_PENALTY_COEFFICIENT = {
     IssueType.MAINTAINABILITY: 0.3,
     IssueType.METHOD_NUMBER: 0.2,
     IssueType.WEIGHTED_METHOD: 0.2,
+    IssueType.UNDEFINED: 0,
+    IssueType.INFO: 0,
 }
 
 

--- a/src/python/review/reviewers/perform_review.py
+++ b/src/python/review/reviewers/perform_review.py
@@ -61,11 +61,11 @@ def perform_and_print_review(path: Path,
 
     if OutputFormat.JSON == output_format:
         if config.new_format:
-            print_review_result_as_multi_file_json(review_result)
+            print_review_result_as_multi_file_json(review_result, config)
         else:
-            print_review_result_as_json(review_result)
+            print_review_result_as_json(review_result, config)
     else:
-        print_review_result_as_text(review_result, path)
+        print_review_result_as_text(review_result, path, config)
 
     # Don't count INFO issues too
     return len(list(filter(lambda issue: issue.type != IssueType.INFO, review_result.all_issues)))

--- a/src/python/review/run_tool.py
+++ b/src/python/review/run_tool.py
@@ -106,6 +106,10 @@ def configure_arguments(parser: argparse.ArgumentParser) -> None:
                         help=RunToolArgument.HISTORY.value.description,
                         type=str)
 
+    parser.add_argument(RunToolArgument.WITH_ALL_CATEGORIES.value.long_name,
+                        help=RunToolArgument.WITH_ALL_CATEGORIES.value.description,
+                        action='store_true')
+
 
 def configure_logging(verbosity: VerbosityLevel) -> None:
     if verbosity is VerbosityLevel.ERROR:
@@ -150,6 +154,7 @@ def main() -> int:
             end_line=args.end_line,
             new_format=args.new_format,
             history=args.history,
+            with_all_categories=args.with_all_categories,
         )
 
         n_issues = perform_and_print_review(args.path, OutputFormat(args.format), config)

--- a/test/python/inspectors/test_local_review.py
+++ b/test/python/inspectors/test_local_review.py
@@ -24,6 +24,7 @@ def config() -> ApplicationConfig:
         allow_duplicates=False,
         n_cpu=1,
         inspectors_config={"n_cpu": 1},
+        with_all_categories=False,
     )
 
 


### PR DESCRIPTION
**Changes**:
- Resolved #50 . Now the tool returns only 5 issue categories: `CODE_STYLE`, `BEST_PRACTICES`, `ERROR_PRONE` and `COMPLEXITY`, `INFO`. This behavior can be changed with the `--with-all-categories` flag. 
- Added support for `INFO` and `UNDEFINED` categories to the penalty system. 