### PR TITLE
Issues fix

### DIFF
--- a/src/python/review/inspectors/checkstyle/files/config.xml
+++ b/src/python/review/inspectors/checkstyle/files/config.xml
@@ -87,16 +87,42 @@
         </module>
         <module name="ConstantName">
             <property name="format" value="^log(ger)?$|^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
+            <message key="name.invalidPattern"
+                     value="Name ''{0}'' must use UPPER_CASE_SNAKE_CASE (checked pattern ''{1}'')."/>
         </module>
-        <module name="LambdaParameterName"/>
-        <module name="LocalFinalVariableName"/>
-        <module name="LocalVariableName"/>
-        <module name="MemberName"/>
-        <module name="MethodName"/>
+        <module name="LambdaParameterName">
+            <message key="name.invalidPattern"
+                     value="Name ''{0}'' must use camelCase (checked pattern ''{1}'')."/>
+        </module>
+        <module name="LocalFinalVariableName">
+            <message key="name.invalidPattern"
+                     value="Name ''{0}'' must use camelCase (checked pattern ''{1}'')."/>
+        </module>
+        <module name="LocalVariableName">
+            <message key="name.invalidPattern"
+                     value="Name ''{0}'' must use camelCase (checked pattern ''{1}'')."/>
+        </module>
+        <module name="MemberName">
+            <message key="name.invalidPattern"
+                     value="Name ''{0}'' must use camelCase (checked pattern ''{1}'')."/>
+        </module>
+        <module name="MethodName">
+            <message key="name.invalidPattern"
+                     value="Name ''{0}'' must use camelCase (checked pattern ''{1}'')."/>
+        </module>
         <module name="PackageName"/>
-        <module name="ParameterName"/>
-        <module name="StaticVariableName"/>
-        <module name="TypeName"/>
+        <module name="ParameterName">
+            <message key="name.invalidPattern"
+                     value="Name ''{0}'' must use camelCase (checked pattern ''{1}'')."/>
+        </module>
+        <module name="StaticVariableName">
+            <message key="name.invalidPattern"
+                     value="Name ''{0}'' must use camelCase (checked pattern ''{1}'')."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+                     value="Name ''{0}'' must use PascalCase (checked pattern ''{1}'')."/>
+        </module>
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->

--- a/src/python/review/inspectors/flake8/.flake8
+++ b/src/python/review/inspectors/flake8/.flake8
@@ -27,6 +27,7 @@ ignore=W291,  # trailing whitespaces
        WPS305, # Forbid f strings.
        WPS306, # Forbid writing classes without base classes.
        WPS318, # Forbid extra indentation. TODO: Collision with standard flake8 indentation check
+       WPS319, # Forbid brackets in the wrong position. (Because of the unnecessary strictness)
        WPS323, # Forbid % formatting on strings.
        WPS324, # Enforce consistent return statements. TODO: Collision with flake8-return
        WPS335, # Forbid wrong for loop iter targets.

--- a/src/python/review/inspectors/flake8/.flake8
+++ b/src/python/review/inspectors/flake8/.flake8
@@ -26,6 +26,7 @@ ignore=W291,  # trailing whitespaces
        WPS303, # Forbid underscores in numbers.
        WPS305, # Forbid f strings.
        WPS306, # Forbid writing classes without base classes.
+       WPS317, # Forbid incorrect indentation for parameters. (Because of the unnecessary strictness)
        WPS318, # Forbid extra indentation. TODO: Collision with standard flake8 indentation check
        WPS319, # Forbid brackets in the wrong position. (Because of the unnecessary strictness)
        WPS323, # Forbid % formatting on strings.

--- a/src/python/review/inspectors/flake8/.flake8
+++ b/src/python/review/inspectors/flake8/.flake8
@@ -32,6 +32,7 @@ ignore=W291,  # trailing whitespaces
        WPS323, # Forbid % formatting on strings.
        WPS324, # Enforce consistent return statements. TODO: Collision with flake8-return
        WPS335, # Forbid wrong for loop iter targets.
+       WPS347, # Forbid imports that may cause confusion outside of the module. (controversial)
        WPS358, # Forbid using float zeros: 0.0.
        WPS359, # Forbids to unpack iterable objects to lists. (Because of its similarity to "WPS414")
        WPS362, # Forbid assignment to a subscript slice.
@@ -52,6 +53,7 @@ ignore=W291,  # trailing whitespaces
        P101, # format string does contain unindexed parameters
        P102, # docstring does contain unindexed parameters
        P103, # other string does contain unindexed parameters
+       F405, # Name may be undefined, or defined from star imports (Collision with the stricter "F403")
        F522, # unused named arguments. TODO: Collision with "P302"
        F523, # unused positional arguments. TODO: Collision with "P301"
        F524, # missing argument. TODO: Collision with "P201" and "P202"

--- a/src/python/review/inspectors/flake8/.flake8
+++ b/src/python/review/inspectors/flake8/.flake8
@@ -33,6 +33,7 @@ ignore=W291,  # trailing whitespaces
        WPS324, # Enforce consistent return statements. TODO: Collision with flake8-return
        WPS335, # Forbid wrong for loop iter targets.
        WPS358, # Forbid using float zeros: 0.0.
+       WPS359, # Forbids to unpack iterable objects to lists. (Because of its similarity to "WPS414")
        WPS362, # Forbid assignment to a subscript slice.
        # WPS: Best practices
        WPS404, # Forbid complex defaults. TODO: Collision with "B006"

--- a/src/python/review/inspectors/pmd/files/bin/basic.xml
+++ b/src/python/review/inspectors/pmd/files/bin/basic.xml
@@ -52,7 +52,8 @@
       </properties>
     </rule>
 <!--    <rule ref="category/java/codestyle.xml/ConfusingTernary"/>-->
-    <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
+    <!-- Disabled due to NeedBracesCheck duplication -->
+    <!-- <rule ref="category/java/codestyle.xml/ControlStatementBraces"/> -->
     <rule ref="category/java/codestyle.xml/DontImportJavaLang"/>
     <rule ref="category/java/codestyle.xml/DuplicateImports"/>
     <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract"/>

--- a/src/python/review/inspectors/pmd/files/bin/basic.xml
+++ b/src/python/review/inspectors/pmd/files/bin/basic.xml
@@ -96,7 +96,8 @@
     <rule ref="category/java/design.xml/AvoidRethrowingException"/>
     <rule ref="category/java/design.xml/AvoidThrowingNewInstanceOfSameException"/>
     <rule ref="category/java/design.xml/AvoidUncheckedExceptionsInSignatures"/>
-    <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
+    <rule ref="category/java/design.xml/CollapsibleIfStatements"
+          message="These nested if statements could be combined by &amp;&amp; operator."/>
 <!--    <rule ref="category/java/design.xml/CouplingBetweenObjects"/>-->
 <!--    <rule ref="category/java/design.xml/CyclomaticComplexity"/>-->
     <rule ref="category/java/design.xml/DoNotExtendJavaLangError"/>

--- a/src/python/review/inspectors/pmd/files/bin/basic.xml
+++ b/src/python/review/inspectors/pmd/files/bin/basic.xml
@@ -46,7 +46,8 @@
     <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/>
     <rule ref="category/java/codestyle.xml/AvoidUsingNativeCode"/>
     <rule ref="category/java/codestyle.xml/BooleanGetMethodName"/>
-    <rule ref="category/java/codestyle.xml/ClassNamingConventions">
+    <rule ref="category/java/codestyle.xml/ClassNamingConventions"
+          message="Name ''{1}'' must use PascalCase (checked pattern ''{2}'').">
       <properties>
         <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)?" />
       </properties>
@@ -59,17 +60,21 @@
     <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract"/>
     <rule ref="category/java/codestyle.xml/ExtendsObject"/>
     <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
-    <rule ref="category/java/codestyle.xml/FieldNamingConventions">
+    <rule ref="category/java/codestyle.xml/FieldNamingConventions"
+          message="Fields must be written using camelCase and constants using UPPER_CASE_SNAKE_CASE. (Incorrect name: ''{1}''. Checked pattern: ''{2}'').">
       <properties>
         <property name="exclusions" value="serialVersionUID|serialPersistentFields|log|logger"/>
       </properties>
     </rule>
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
-    <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"/>
+    <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"
+          message="Name ''{1}'' must use camelCase (checked pattern ''{2}'')."/>
     <rule ref="category/java/codestyle.xml/IdenticalCatchBranches"/>
 <!--    <rule ref="category/java/codestyle.xml/LinguisticNaming"/>-->
-    <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"/>
-    <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
+    <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"
+          message="Name ''{1}'' must use camelCase (checked pattern ''{2}'')."/>
+    <rule ref="category/java/codestyle.xml/MethodNamingConventions"
+          message="Name ''{1}'' must use camelCase (checked pattern ''{2}'')."/>
     <rule ref="category/java/codestyle.xml/PackageCase"/>
 <!--    <rule ref="category/java/codestyle.xml/TooManyStaticImports">-->
 <!--      <properties>-->

--- a/src/python/review/inspectors/pylint/issue_types.py
+++ b/src/python/review/inspectors/pylint/issue_types.py
@@ -8,6 +8,7 @@ from src.python.review.inspectors.issue import IssueType
 # E errors, for probable bugs in the code
 
 CODE_TO_ISSUE_TYPE: Dict[str, IssueType] = {
+    'C0200': IssueType.BEST_PRACTICES,  # consider using enumerate
     'W0101': IssueType.ERROR_PRONE,  # unreachable code
     'W0102': IssueType.ERROR_PRONE,  # dangerous default value
     'W0104': IssueType.ERROR_PRONE,  # statement doesn't have any effect

--- a/src/python/review/inspectors/pylint/pylintrc
+++ b/src/python/review/inspectors/pylint/pylintrc
@@ -165,6 +165,7 @@ disable=invalid-name,
         no-else-break,
         no-else-continue,
         W0614,
+        W0622,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/python/review/inspectors/pylint/pylintrc
+++ b/src/python/review/inspectors/pylint/pylintrc
@@ -164,6 +164,7 @@ disable=invalid-name,
         no-else-raise,
         no-else-break,
         no-else-continue,
+        W0614,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/test/python/inspectors/test_flake8_inspector.py
+++ b/test/python/inspectors/test_flake8_inspector.py
@@ -34,6 +34,7 @@ FILE_NAMES_AND_N_ISSUES = [
     ('case33_commas.py', 14),
     ('case34_cohesion.py', 1),
     ('case35_line_break.py', 11),
+    ('case36_unpacking.py', 3),
 ]
 
 
@@ -76,6 +77,7 @@ FILE_NAMES_AND_N_ISSUES_INFO = [
     ('case32_string_format.py', IssuesTestInfo(n_error_prone=28, n_other_complexity=6)),
     ('case33_commas.py', IssuesTestInfo(n_code_style=14, n_cc=4)),
     ('case34_cohesion.py', IssuesTestInfo(n_cc=6, n_cohesion=2)),
+    ('case36_unpacking.py', IssuesTestInfo(n_error_prone=2, n_cc=1, n_other_complexity=1)),
 ]
 
 

--- a/test/python/inspectors/test_flake8_inspector.py
+++ b/test/python/inspectors/test_flake8_inspector.py
@@ -35,6 +35,7 @@ FILE_NAMES_AND_N_ISSUES = [
     ('case34_cohesion.py', 1),
     ('case35_line_break.py', 11),
     ('case36_unpacking.py', 3),
+    ('case37_wildcard_import.py', 7),
 ]
 
 
@@ -78,6 +79,7 @@ FILE_NAMES_AND_N_ISSUES_INFO = [
     ('case33_commas.py', IssuesTestInfo(n_code_style=14, n_cc=4)),
     ('case34_cohesion.py', IssuesTestInfo(n_cc=6, n_cohesion=2)),
     ('case36_unpacking.py', IssuesTestInfo(n_error_prone=2, n_cc=1, n_other_complexity=1)),
+    ('case37_wildcard_import.py', IssuesTestInfo(n_best_practices=1, n_error_prone=3, n_cc=2, n_other_complexity=2)),
 ]
 
 

--- a/test/python/inspectors/test_pmd_inspector.py
+++ b/test/python/inspectors/test_pmd_inspector.py
@@ -15,7 +15,7 @@ FILE_NAMES_AND_N_ISSUES = [
     ('test_comparing_strings.java', 3),
     ('test_constants.java', 4),
     ('test_covariant_equals.java', 1),
-    ('test_curly_braces.java', 2),
+    ('test_curly_braces.java', 0),
     ('test_double_checked_locking.java', 2),
     ('test_for_loop.java', 2),
     ('test_implementation_types.java', 0),

--- a/test/python/inspectors/test_pylint_inspector.py
+++ b/test/python/inspectors/test_pylint_inspector.py
@@ -11,7 +11,7 @@ FILE_NAMES_AND_N_ISSUES = [
     ('case0_spaces.py', 0),
     ('case1_simple_valid_program.py', 0),
     ('case2_boolean_expressions.py', 3),
-    ('case3_redefining_builtin.py', 2),
+    ('case3_redefining_builtin.py', 0),
     ('case4_naming.py', 3),
     ('case5_returns.py', 1),
     ('case6_unused_variables.py', 4),
@@ -32,6 +32,8 @@ FILE_NAMES_AND_N_ISSUES = [
     ('case25_django.py', 0),
     ('case27_using_requests.py', 0),
     ('case30_allow_else_return.py', 0),
+    ('case36_unpacking.py', 0),
+    ('case37_wildcard_import.py', 1),
 ]
 
 

--- a/test/resources/inspectors/python/case36_unpacking.py
+++ b/test/resources/inspectors/python/case36_unpacking.py
@@ -1,0 +1,10 @@
+[a, b, c], [x, y, z] = (sorted(map(int, input().split())) for _ in 'lm')
+if [a, b, c] == [x, y, z]:
+    a = "Boxes are equal"
+elif a <= x and b <= y and c <= z:
+    a = "The first box is smaller than the second one"
+elif a >= x and b >= y and c >= z:
+    a = "The first box is larger than the second one"
+else:
+    a = "Boxes are incomparable"
+print(a)

--- a/test/resources/inspectors/python/case37_wildcard_import.py
+++ b/test/resources/inspectors/python/case37_wildcard_import.py
@@ -1,0 +1,33 @@
+from numpy import *
+
+n, m = [int(_) for _ in input().split()]
+mat = zeros((n, m))
+s = 1
+for j in range(n):
+    for i in range(j, m - j):
+        if s > n * m:
+            break
+        mat[j][i] = s
+        s += 1
+
+    for i in range(j - n + 1, -j):
+        if s > n * m:
+            break
+        mat[i][-j - 1] = s
+        s += 1
+    for i in range(-j - 2, -m + j - 1, -1):
+        if s > n * m:
+            break
+        mat[-j - 1][i] = s
+        s += 1
+
+    for i in range(-2 - j, -n + j, -1):
+        if s > n * m:
+            break
+        mat[i][j] = s
+        s += 1
+
+for r in range(n):
+    for c in range(m):
+        print(str(int(mat[r][c])).ljust(2), end=' ')
+    print()


### PR DESCRIPTION
**Changes**:
- Fixed #70.
- Fixed #71. Removed `WPS317` because of its strictness.
- Fixed #72. Removed `ControlStatementBraces`.
- Partially fixed #73. Fixed message for `LocalVariableNameCheck` and other similar inspections where regexp is in the message.
- Fixed #77. 
- Fixed #78. Removed `W0614`, so pylint is able to find wildcard imports using the less strict `W0401`.
- Fixed #79. Removed `WPS359` because `WPS414` is similar to `WPS359`, but can find more cases.
- Fixed #81.
- Added `F405` to ignore, since we have a stricter `F403`.
- Added `WPS347` to ignore, as the rule is controversial.
- Added `W0622` (redefining builtin) to ignore, because the rule does not behave correctly with wildacard imports. Now only flake8 finds problems related to redefining buildins