### PR TITLE
Add language parameter to inspect only one specific language

### DIFF
--- a/hyperstyle/src/python/common/tool_arguments.py
+++ b/hyperstyle/src/python/common/tool_arguments.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from enum import Enum, unique
 from typing import List, Optional
 
+from hyperstyle.src.python.review.common.language import Language
 from hyperstyle.src.python.review.application_config import LanguageVersion
 from hyperstyle.src.python.review.inspectors.inspector_type import InspectorType
 
@@ -50,8 +51,13 @@ class RunToolArgument(Enum):
                                'Allow duplicate issues found by different linters. '
                                'By default, duplicates are skipped.')
 
+    LANG = ArgumentsInfo(None, '--language',
+                                 'Specify the language to inspect. The tool will check all languages by default. '
+                                 'Available values are: '
+                                 f'{", ".join([l.lower() for l in Language.values()])}.')
+
     LANG_VERSION = ArgumentsInfo(None, '--language-version',
-                                 'Specify the language version for JAVA inspectors.'
+                                 'Specify the language version for JAVA inspectors. '
                                  'Available values are: '
                                  f'{LanguageVersion.PYTHON_3.value}, {LanguageVersion.JAVA_8.value}, '
                                  f'{LanguageVersion.JAVA_11.value}, {LanguageVersion.KOTLIN.value}.')

--- a/hyperstyle/src/python/review/reviewers/perform_review.py
+++ b/hyperstyle/src/python/review/reviewers/perform_review.py
@@ -99,7 +99,11 @@ def perform_review(path: Path, config: ApplicationConfig) -> GeneralReviewResult
 
 def _preform_review(metadata: Metadata, languages: List[Language], config: ApplicationConfig) -> GeneralReviewResult:
     # TODO start review for several languages and do something with the results
-    reviewer = language_to_reviewer[languages[0]]
+    if config.inspectors_config['language'] == Language.UNKNOWN:
+        language = languages[0]
+    else:
+        language = config.inspectors_config['language']
+    reviewer = language_to_reviewer[language]
     return reviewer(metadata, config)
 
 

--- a/hyperstyle/src/python/review/run_tool.py
+++ b/hyperstyle/src/python/review/run_tool.py
@@ -10,6 +10,7 @@ from typing import Set
 sys.path.append('')
 sys.path.append('../../../..')
 
+from hyperstyle.src.python.review.common.language import Language
 from hyperstyle.src.python.common.tool_arguments import RunToolArgument, VerbosityLevel
 from hyperstyle.src.python.review.application_config import ApplicationConfig, LanguageVersion
 from hyperstyle.src.python.review.inspectors.inspector_type import InspectorType
@@ -63,6 +64,12 @@ def configure_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(RunToolArgument.DUPLICATES.value.long_name,
                         action='store_true',
                         help=RunToolArgument.DUPLICATES.value.description)
+
+    parser.add_argument(RunToolArgument.LANG.value.long_name,
+                        help=RunToolArgument.LANG.value.description,
+                        default=None,
+                        choices=[l.lower() for l in Language.values()],
+                        type=str)
 
     # TODO: deprecated argument: language_version. Delete after several releases.
     parser.add_argument('--language_version',
@@ -151,6 +158,7 @@ def main() -> int:
             start_line = 1
 
         inspectors_config = {
+            "language": Language(args.language.upper()),
             'language_version': LanguageVersion(args.language_version) if args.language_version is not None else None,
             'n_cpu': n_cpu,
         }


### PR DESCRIPTION
Currently, hyperstyle detects languages in project and run checks only for one language. 

If we run it on a project with more than one language, a random language from the detected languages will select. So inspection results will get different results on each run.

I added a `--language` parameter to set specific language for inspection to avoid random results for such cases. By default, language selection logic stays the same.